### PR TITLE
proper setting for minimize attribute

### DIFF
--- a/test/test_NCLModel.jl
+++ b/test/test_NCLModel.jl
@@ -58,7 +58,7 @@ function test_NLCModel(test::Bool) ::Test.DefaultTestSet
                 @testset "NCLModel struct information about nlp" begin
                     @test nlc_nlin_res.nx == 2
                     @test nlc_nlin_res.nr == 2 # two non linear constraint, so two residues
-                    @test nlc_nlin_res.minimize == true
+                    @test nlc_nlin_res.meta.minimize == true
                 end
 
                 @testset "NCLModel struct constant parameters" begin
@@ -211,7 +211,7 @@ function test_NLCModel(test::Bool) ::Test.DefaultTestSet
                 @testset "NCLModel struct information about nlp" begin
                     @test nlc_cons_res.nx == 2
                     @test nlc_cons_res.nr == 4 # two non linear constraint, so two residues
-                    @test nlc_cons_res.minimize == true
+                    @test nlc_cons_res.meta.minimize == true
                 end
 
                 @testset "NCLModel struct constant parameters" begin


### PR DESCRIPTION
I propose that we always consider that the NCLModel is a minimization problem. The "sense" of the original problem is in `ncl.nlp.meta.minimize`.

Currently, "minimize" is only taken into account in `obj`. We should also properly treat "minimize" in the other methods.